### PR TITLE
feat: 添加「随读」随机书目功能

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -139,6 +139,10 @@ menu:
       name: 书目
       url: /books.html
       weight: -90
+    - identifier: random
+      name: 随读
+      url: /random.html
+      weight: -85
     - identifier: syyj
       name: 声音邮局
       url: /syyj.html

--- a/content/random.md
+++ b/content/random.md
@@ -1,0 +1,5 @@
+---
+title: "随读"
+type: "page"
+layout: "random"
+---

--- a/layouts/page/random.html
+++ b/layouts/page/random.html
@@ -1,0 +1,13 @@
+{{ define "main" }}
+<script>
+  var books = [
+    {{ range where .Site.RegularPages "Section" "books" }}"{{ .RelPermalink }}",
+    {{ end }}
+  ];
+  window.location.href = books[Math.floor(Math.random() * books.length)];
+</script>
+<noscript>
+  <p>请启用 JavaScript 以使用随读功能。</p>
+  <p><a href="/books.html">浏览所有书目</a></p>
+</noscript>
+{{ end }}


### PR DESCRIPTION
## 随读功能

点击菜单中的「随读」，会随机跳转到一本书的页面。

### 改动
- `content/random.md` — 随读页面内容
- `layouts/page/random.html` — 随机跳转模板（Hugo 构建时生成书目列表，JS 随机选择并跳转）
- `config.yaml` — 在导航菜单中添加「随读」入口（位于「书目」之后）

### 实现方式
Hugo 在构建时将所有 `books` section 的页面 URL 写入数组，访问 `/random.html` 时 JavaScript 随机选取一个并立即跳转。无需外部 API，加载即跳转。